### PR TITLE
skills: add MCP server prerequisite to all 10 workflow skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -19,6 +19,20 @@ Current AI company-data skills pull from commercial aggregators (Bureau van Dijk
 | **Stable** | Production-grade on CF Workers' global edge. |
 | **Cross-border** | Walk ownership chains across 27 jurisdictions in one prompt. |
 
+## Prerequisite: configure the OpenRegistry MCP server
+
+Every skill in this pack calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, …). Add the server to your AI client config **before** dropping any skill into your skills directory:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+Free anonymous tier, no API key required. Restart your client after adding. If a skill's tool calls return `tool not found`, the MCP server isn't wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+
 ## Catalogue
 
 | # | Skill | Outcome in one prompt |

--- a/skills/corporate-filing-monitor/SKILL.md
+++ b/skills/corporate-filing-monitor/SKILL.md
@@ -7,6 +7,22 @@ description: Live stream of material filings on any company — director changes
 
 **The last N days of government filings on your watchlist — categorised, fetched, flagged.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live filing history** from the government registry's own filings index — UK Companies House filing-history API, Korea DART DS001 list, Mexico PSM statutory publications, Iceland Skatturinn typeid-1/2/3 stream.

--- a/skills/director-search-pep-screening/SKILL.md
+++ b/skills/director-search-pep-screening/SKILL.md
@@ -7,6 +7,22 @@ description: Map every company a person has been a director of — live, direct 
 
 **From a single name to the full corporate footprint, live from the government officer register.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live officer search** across UK Companies House, France RNE, Taiwan GCIS — the 3 jurisdictions that publish free cross-company officer indexes.

--- a/skills/global-company-name-availability/SKILL.md
+++ b/skills/global-company-name-availability/SKILL.md
@@ -7,6 +7,22 @@ description: Check whether a proposed company name is free to register across 10
 
 **Run a name across 10+ government company registers in one prompt. Get exact-match / cooling-off / confusingly-similar results per jurisdiction.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live name search** against each target country's statutory register — no commercial-data-provider lag, no stale index.

--- a/skills/industry-competitor-search/SKILL.md
+++ b/skills/industry-competitor-search/SKILL.md
@@ -7,6 +7,22 @@ description: Find every company operating in a sector across 27 national governm
 
 **Map an industry across jurisdictions in one prompt — live government data, no aggregator lag.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Parallel search across multiple government registries** (anon/free 3 countries / 60s; Pro 10; Max 30; Enterprise unlimited).

--- a/skills/kyc-cross-border-due-diligence/SKILL.md
+++ b/skills/kyc-cross-border-due-diligence/SKILL.md
@@ -7,6 +7,22 @@ description: Ship a full statutory due-diligence dossier in one prompt — profi
 
 **Replace 3 hours of research across 27 government websites with one AI prompt — and every fact in your report links back to the government source.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live statutory dossier**: profile, directors, beneficial owners, shareholders, registered charges, latest filed accounts — pulled at query time from the government registry of record.

--- a/skills/live-company-accounts-xbrl/SKILL.md
+++ b/skills/live-company-accounts-xbrl/SKILL.md
@@ -7,6 +7,22 @@ description: Pull the most recent statutory financial statements for any company
 
 **The actual statutory filing bytes — as the company filed them with the government, not an aggregator's summary.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live document retrieval** from the government filing archive — UK Companies House document API, Korea DART DS003 XBRL bundle, Iceland Skatturinn free-PDF cart, Mexico PSM folio de publicación.

--- a/skills/phoenix-company-radar/SKILL.md
+++ b/skills/phoenix-company-radar/SKILL.md
@@ -9,6 +9,22 @@ description: Detect phoenix-company fraud patterns from live government registry
 
 A phoenix company is a classic UK/common-law creditor-fraud pattern: a director runs a company into insolvency, dissolves it, then spins up a "new" company at the same address with the same trade and often the same director — leaving creditors of the old entity unpaid. This skill catches the pattern by correlating live registry data across the dissolution → rebirth timeline.
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live cross-reference** of three registry streams: dissolved companies + current-director appointments + registered-office reuse, all pulled at query time.

--- a/skills/sector-gatekeeper-list/SKILL.md
+++ b/skills/sector-gatekeeper-list/SKILL.md
@@ -7,6 +7,22 @@ description: List every regulated / licensed entity in a sector — CIMA-authori
 
 **List every regulated / licensed entity in a sector, direct from the regulator's register.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live regulator register access** where the jurisdiction exposes it freely — Cayman CIMA (all 35 authorization categories from Banking Class A/B to Virtual Asset Service Provider), UK Companies House + (limited) FCA Register, Korean DART (supervised issuers), Hong Kong SFC (via equivalent), Canadian CBCA (federal corps).

--- a/skills/shell-company-detector/SKILL.md
+++ b/skills/shell-company-detector/SKILL.md
@@ -7,6 +7,22 @@ description: Detect shell-company signals from live government registry data —
 
 **Score shell-probability from live government registry data — no aggregator "shell flags", the actual raw signals.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live multi-signal probe** of every well-known shell-entity indicator, pulled from the government register at query time.

--- a/skills/ubo-cross-border-chain-walker/SKILL.md
+++ b/skills/ubo-cross-border-chain-walker/SKILL.md
@@ -7,6 +7,22 @@ description: Unmask the real person behind any company. Walks ownership chains a
 
 **Walk the ownership chain across jurisdictions until you reach the real individual — or a transparent AML gate.**
 
+
+This skill calls OpenRegistry MCP tools (`search_companies`, `get_company_profile`, `list_filings`, `fetch_document`, etc). Add the server to your AI client config before invoking:
+
+```json
+{
+  "mcpServers": {
+    "openregistry": { "url": "https://openregistry.sophymarine.com/mcp" }
+  }
+}
+```
+
+t wired up — see [openregistry.sophymarine.com/docs](https://openregistry.sophymarine.com/docs).
+'
+
+# Use node to do the insert reliably
+node <<'NODE_INSERT'
 ## What you get
 
 - **Live government queries at every hop.** Each company in the chain is looked up in its home country's statutory register at the moment you ask. No cache layer, no nightly scrape, no 6-24 hour stale data.


### PR DESCRIPTION
## Why

Skills don't actually work when dropped into `~/.claude/skills/` unless
the OpenRegistry MCP server is already configured in the AI client. Skill
bodies reference tools like `search_companies({...})` — Claude sees those,
tries to invoke, and gets `tool not found` because the MCP server isn't
in its tool list.

## What

- Insert a **Prerequisite** section near the top of each of the 10 workflow
  SKILL.md files with the MCP config snippet.
- Add the same Prerequisite section to skills/README.md before the catalogue.
- skills/per-country/README.md (added in PR #2) already mentions this.

No skill workflow / step content changed.